### PR TITLE
Use Language settings from the Core for Picotts insteade of default language

### DIFF
--- a/core/class/sonos3.class.php
+++ b/core/class/sonos3.class.php
@@ -987,6 +987,7 @@ class sonos3Cmd extends cmd {
 				$track->getProvider()->setVoice(config::byKey('ttsVoxygenVoice', 'sonos3', 'Helene'));
 			} else if (config::byKey('ttsProvider', 'sonos3') == 'picotts') {
 				$track = new TextToSpeech(trim($_options['message']), $directory, new PicottsProvider);
+				$track->getProvider()->setLanguage(str_replace ('_', '-', config::byKey('language','core')));
 			}
 			if ($_options['title'] != '' && is_numeric($_options['title'])) {
 				$controller->interrupt($track, $_options['title']);

--- a/vendor/duncan3dc/speaker/src/Providers/PicottsProvider.php
+++ b/vendor/duncan3dc/speaker/src/Providers/PicottsProvider.php
@@ -50,13 +50,12 @@ class PicottsProvider extends AbstractProvider
      */
     public function setLanguage($language)
     {
-        $language = strtolower(trim($language));
-
         if (strlen($language) === 2) {
-            $language = "{$language}-{$language}";
+			$language = strtolower(trim($language));
+            $language = "{$language}-" . strtoupper($language);
         }
 
-        if (!preg_match("/^[a-z]{2}-[a-z]{2}$/", $language)) {
+        if (!preg_match("/^[a-z]{2}-[A-Z]{2}$/", $language)) {
             throw new \InvalidArgumentException("Unexpected language code ({$language}), codes should be 2 characters, a hyphen, and a further 2 characters");
         }
 


### PR DESCRIPTION
The proposed correction will use the language settings from the core instead of the default en-US language for tts via PicoTts.

The sonos-plugin correction also require a bug fix in the duncan3dc/speaker library.
==> This fix is included in the current pull request, but as also been proposed https://github.com/duncan3dc/speaker/pull/4 and accepted in the original repository. [Available in release 0.7.1](https://github.com/duncan3dc/speaker/releases/tag/0.7.1)