### PR TITLE
Update volume immediately for high speed scenario

### DIFF
--- a/core/class/sonos3.class.php
+++ b/core/class/sonos3.class.php
@@ -1055,6 +1055,7 @@ class sonos3Cmd extends cmd {
 				$_options['slider'] = 100;
 			}
 			$controller->setVolume($_options['slider']);
+			$eqLogic->getCmd(null, 'volume')->event($_options['slider']);
 		} elseif ($this->getLogicalId() == 'play_playlist') {
 			if (!$controller->isUsingQueue()) {
 				$controller->useQueue();


### PR DESCRIPTION
Hi,

I'm using a Symfonisk Sound Remote (E1744) that throws multiple rotate messages every 0.2s
Using a scenario, I were not able to lower the volume conveniently : 
- first scenario execution read "volume statut", lower it, then Set new volume
- subsequent execution read the same "volume statut" and Set the same new value 
Because background pulling occurs not so fast...

So after Volume is setted up, I'm saving this new value into "Volume Statut" allowing subsequent scenario execution to do his job properly.

Result : 
```
[2020-12-16 23:57:56][INFO] : Evènement sur la commande [Multimédia][Volume SDB RDC][action] valeur : rotate_right
[2020-12-16 23:57:56][INFO] : Exécution du scénario [Multimédia][Gestion SDB RDC] déclenché par : [Multimédia][Volume SDB RDC][action]
[2020-12-16 23:57:56][INFO] : Exécution de la commande [Multimédia][Salle De Bain][Volume] avec les paramètres {"background":"0","slider":"5"}
[2020-12-16 23:57:56][INFO] : Evènement sur la commande [Multimédia][Salle De Bain][Volume statut] valeur : 5
[2020-12-16 23:57:56][INFO] : Evènement sur la commande [Multimédia][Volume SDB RDC][action] valeur : rotate_right
[2020-12-16 23:57:56][INFO] : Exécution du scénario [Multimédia][Gestion SDB RDC] déclenché par : [Multimédia][Volume SDB RDC][action]
[2020-12-16 23:57:56][INFO] : Exécution de la commande [Multimédia][Salle De Bain][Volume] avec les paramètres {"background":"0","slider":"10"}
[2020-12-16 23:57:56][INFO] : Evènement sur la commande [Multimédia][Salle De Bain][Volume statut] valeur : 10
[2020-12-16 23:57:56][INFO] : Evènement sur la commande [Multimédia][Volume SDB RDC][action] valeur : rotate_right
[2020-12-16 23:57:56][INFO] : Exécution du scénario [Multimédia][Gestion SDB RDC] déclenché par : [Multimédia][Volume SDB RDC][action]
[2020-12-16 23:57:56][INFO] : Exécution de la commande [Multimédia][Salle De Bain][Volume] avec les paramètres {"background":"0","slider":"15"}
[2020-12-16 23:57:56][INFO] : Evènement sur la commande [Multimédia][Salle De Bain][Volume statut] valeur : 15
[2020-12-16 23:57:56][INFO] : Evènement sur la commande [Multimédia][Volume SDB RDC][action] valeur : rotate_right
[2020-12-16 23:57:56][INFO] : Exécution du scénario [Multimédia][Gestion SDB RDC] déclenché par : [Multimédia][Volume SDB RDC][action]
[2020-12-16 23:57:56][INFO] : Exécution de la commande [Multimédia][Salle De Bain][Volume] avec les paramètres {"background":"0","slider":"20"}
[2020-12-16 23:57:56][INFO] : Evènement sur la commande [Multimédia][Salle De Bain][Volume statut] valeur : 20
[2020-12-16 23:57:57][INFO] : Evènement sur la commande [Multimédia][Volume SDB RDC][action] valeur : rotate_right
[2020-12-16 23:57:57][INFO] : Exécution du scénario [Multimédia][Gestion SDB RDC] déclenché par : [Multimédia][Volume SDB RDC][action]
[2020-12-16 23:57:57][INFO] : Exécution de la commande [Multimédia][Salle De Bain][Volume] avec les paramètres {"background":"0","slider":"25"}
```